### PR TITLE
build: update github actions to v4 to fix cache api deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -37,9 +37,9 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org/"


### PR DESCRIPTION
Updated `actions/checkout` and `actions/setup-node` in `.github/workflows/ci.yml` from v3 to v4. This is necessary because GitHub Actions is deprecating older node versions and the legacy cache service API used by v3 of `actions/setup-node`. By bumping to v4, the workflow will use the modern v2 cache service API and run on updated Node.js runtimes, effectively resolving the pending deprecation warnings.

---
*PR created automatically by Jules for task [9794128807671660109](https://jules.google.com/task/9794128807671660109) started by @lhemerly*