### PR TITLE
docs: Add missing API Documentation heading to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,8 @@ npm install shoggoth
 
 Shoggoth provides the base objects for a simple implementation. You should extend the base classes to customize the shoggoth to your needs.
 
+## API Documentation
+
 Please refer to the Github Wiki:
 
 [shoggoth docs](https://github.com/lhemerly/shoggoth/wiki)


### PR DESCRIPTION
The README's Table of Contents had a link pointing to `#api-documentation`, but the corresponding header was missing in the document. The link to the Github Wiki was instead just nested directly under the `## Usage` section. This commit fixes that inconsistency by creating a new `## API Documentation` section containing the Wiki link, making the formatting structurally sound and matching the TOC.

---
*PR created automatically by Jules for task [3246600122703021926](https://jules.google.com/task/3246600122703021926) started by @lhemerly*